### PR TITLE
ibm-ups: Initial version of UPS application

### DIFF
--- a/ibm-ups/device.hpp
+++ b/ibm-ups/device.hpp
@@ -1,0 +1,90 @@
+/**
+ * Copyright © 2021 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <org/freedesktop/UPower/Device/server.hpp>
+#include <sdbusplus/server/object.hpp>
+
+/**
+ * This file contains data types and constants related to the
+ * org.freedesktop.UPower.Device interface.
+ */
+
+namespace phosphor::power::ibm_ups
+{
+
+/**
+ * Define simple name for the generated C++ class that implements the
+ * org.freedesktop.UPower.Device interface.
+ */
+using DeviceInterface = sdbusplus::org::freedesktop::UPower::server::Device;
+
+/**
+ * Define simple name for the sdbusplus object_t class that implements all
+ * the necessary D-Bus interfaces via templates/multiple inheritance.
+ */
+using DeviceObject = sdbusplus::server::object_t<DeviceInterface>;
+
+namespace device
+{
+
+/**
+ * Defined values for the Type property.
+ */
+namespace type
+{
+constexpr auto Unknown = 0;
+constexpr auto LinePower = 1;
+constexpr auto Battery = 2;
+constexpr auto Ups = 3;
+constexpr auto Monitor = 4;
+constexpr auto Mouse = 5;
+constexpr auto Keyboard = 6;
+constexpr auto Pda = 7;
+constexpr auto Phone = 8;
+} // namespace type
+
+/**
+ * Defined values for the State property.
+ */
+namespace state
+{
+constexpr auto Unknown = 0;
+constexpr auto Charging = 1;
+constexpr auto Discharging = 2;
+constexpr auto Empty = 3;
+constexpr auto FullyCharged = 4;
+constexpr auto PendingCharge = 5;
+constexpr auto PendingDischarge = 6;
+} // namespace state
+
+/**
+ * Defined values for the BatteryLevel property.
+ */
+namespace battery_level
+{
+constexpr auto Unknown = 0;
+constexpr auto None = 1;
+constexpr auto Low = 3;
+constexpr auto Critical = 4;
+constexpr auto Normal = 6;
+constexpr auto High = 7;
+constexpr auto Full = 8;
+} // namespace battery_level
+
+} // namespace device
+
+} // namespace phosphor::power::ibm_ups

--- a/ibm-ups/main.cpp
+++ b/ibm-ups/main.cpp
@@ -1,0 +1,33 @@
+/**
+ * Copyright © 2021 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "monitor.hpp"
+
+#include <sdbusplus/bus.hpp>
+#include <sdeventplus/event.hpp>
+
+int main(void)
+{
+    using namespace phosphor::power::ibm_ups;
+
+    auto bus = sdbusplus::bus::new_default();
+    auto event = sdeventplus::Event::get_default();
+    bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
+
+    Monitor monitor{bus, event};
+
+    return event.loop();
+}

--- a/ibm-ups/meson.build
+++ b/ibm-ups/meson.build
@@ -1,0 +1,13 @@
+ibm_ups = executable(
+    'ibm-ups',
+    'main.cpp',
+    'monitor.cpp',
+    'ups.cpp',
+    dependencies: [
+        phosphor_dbus_interfaces,
+        phosphor_logging,
+        sdbusplus,
+        sdeventplus
+    ],
+    install: true
+)

--- a/ibm-ups/monitor.cpp
+++ b/ibm-ups/monitor.cpp
@@ -1,0 +1,34 @@
+/**
+ * Copyright © 2021 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "monitor.hpp"
+
+namespace phosphor::power::ibm_ups
+{
+
+/**
+ * D-Bus service/bus name for this application.
+ */
+constexpr auto serviceName = "xyz.openbmc_project.Power.IBMUPS";
+
+Monitor::Monitor(sdbusplus::bus::bus& bus, const sdeventplus::Event& event) :
+    bus{bus}, eventLoop{event}, ups{bus}
+{
+    // Obtain D-Bus service name
+    bus.request_name(serviceName);
+}
+
+} // namespace phosphor::power::ibm_ups

--- a/ibm-ups/monitor.hpp
+++ b/ibm-ups/monitor.hpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright © 2021 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "ups.hpp"
+
+#include <sdbusplus/bus.hpp>
+#include <sdeventplus/event.hpp>
+
+namespace phosphor::power::ibm_ups
+{
+
+/**
+ * @class Monitor
+ *
+ * Monitors an Uninterruptible Power Supply (UPS) device.
+ */
+class Monitor
+{
+  public:
+    // Specify which compiler-generated methods we want
+    Monitor() = delete;
+    Monitor(const Monitor&) = delete;
+    Monitor(Monitor&&) = delete;
+    Monitor& operator=(const Monitor&) = delete;
+    Monitor& operator=(Monitor&&) = delete;
+    ~Monitor() = default;
+
+    /**
+     * Constructor
+     *
+     * @param bus D-Bus bus object
+     * @param event event object
+     */
+    explicit Monitor(sdbusplus::bus::bus& bus, const sdeventplus::Event& event);
+
+  private:
+    /**
+     * D-Bus bus object.
+     */
+    sdbusplus::bus::bus& bus;
+
+    /**
+     * Event object to loop on.
+     */
+    const sdeventplus::Event& eventLoop;
+
+    /**
+     * UPS device.
+     */
+    UPS ups;
+};
+
+} // namespace phosphor::power::ibm_ups

--- a/ibm-ups/ups.cpp
+++ b/ibm-ups/ups.cpp
@@ -1,0 +1,46 @@
+/**
+ * Copyright © 2021 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ups.hpp"
+
+namespace phosphor::power::ibm_ups
+{
+
+/**
+ * D-Bus object path for the UPS.
+ *
+ * The UPower open source package is not used by this application.  However, the
+ * UPower Device interface is used to publish the UPS status on D-Bus.  As a
+ * result, a UPower-style D-Bus object path is used.
+ */
+constexpr auto objectPath = "/org/freedesktop/UPower/devices/ups_hiddev0";
+
+UPS::UPS(sdbusplus::bus::bus& bus) : DeviceObject{bus, objectPath, true}
+{
+    // Set D-Bus properties that do not have the correct default value.  Skip
+    // emitting D-Bus signals until the object has been fully created.
+    bool skipSignal{true};
+    type(device::type::Ups, skipSignal);
+    powerSupply(true, skipSignal);
+    state(device::state::FullyCharged, skipSignal);
+    isRechargeable(true, skipSignal);
+    batteryLevel(device::battery_level::Full, skipSignal);
+
+    // Now emit signal that object has been created
+    emit_object_added();
+}
+
+} // namespace phosphor::power::ibm_ups

--- a/ibm-ups/ups.hpp
+++ b/ibm-ups/ups.hpp
@@ -1,0 +1,102 @@
+/**
+ * Copyright © 2021 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "device.hpp"
+
+#include <sdbusplus/bus.hpp>
+
+#include <cstdint>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace phosphor::power::ibm_ups
+{
+
+/**
+ * @class UPS
+ *
+ * This class represents an Uninterruptible Power Supply (UPS) device.
+ *
+ * The UPS must be connected to the system using an IBM System Port Converter
+ * Cable.  This USB cable allows for communications from a UPS relay interface
+ * card to a BMC USB port.
+ *
+ * The UPS status is read from the USB cable.  The status is published on D-Bus
+ * using the UPower Device interface.
+ *
+ * The PLDM application uses the D-Bus information to build PLDM state sensors.
+ * These state sensors communicate the UPS status to the host operating system.
+ *
+ * If a UPS is not connected to the system, the IsPresent property of the D-Bus
+ * interface is set to false.  The D-Bus object for the UPS always exists.  This
+ * is required due to the way PLDM maps the D-Bus interface properties into PLDM
+ * state sensors.
+ */
+class UPS : public DeviceObject
+{
+  public:
+    // Specify which compiler-generated methods we want
+    UPS() = delete;
+    UPS(const UPS&) = delete;
+    UPS(UPS&&) = delete;
+    UPS& operator=(const UPS&) = delete;
+    UPS& operator=(UPS&&) = delete;
+    virtual ~UPS() = default;
+
+    /**
+     * Constructor.
+     *
+     * @param bus D-Bus bus object
+     */
+    explicit UPS(sdbusplus::bus::bus& bus);
+
+    /**
+     * Refreshes the UPS device status by reading from the UPS cable.
+     */
+    virtual void refresh() override
+    {
+        // Not implemented yet
+    }
+
+    /**
+     * Gets history for the UPS device that is persistent across reboots.
+     *
+     * This method from the Device interface is not supported.  History is not
+     * available from the USB cable interface.
+     */
+    virtual std::vector<std::tuple<uint32_t, double, uint32_t>>
+        getHistory(std::string /*type*/, uint32_t /*timespan*/,
+                   uint32_t /*resolution*/) override
+    {
+        return std::vector<std::tuple<uint32_t, double, uint32_t>>{};
+    }
+
+    /**
+     * Gets statistics for the UPS device.
+     *
+     * This method from the Device interface is not supported.  Statistics are
+     * not available from the USB cable interface.
+     */
+    virtual std::vector<std::tuple<double, double>>
+        getStatistics(std::string /*type*/) override
+    {
+        return std::vector<std::tuple<double, double>>{};
+    }
+};
+
+} // namespace phosphor::power::ibm_ups

--- a/meson.build
+++ b/meson.build
@@ -49,6 +49,7 @@ systemd = dependency('systemd')
 servicedir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
 
 services = [
+    ['ibm-ups', 'ibm-ups.service'],
     ['supply-monitor', 'power-supply-monitor@.service'],
     ['sequencer-monitor', 'pseq-monitor-pgood.service'],
     ['sequencer-monitor', 'pseq-monitor.service'],
@@ -124,6 +125,9 @@ libpower_inc = include_directories('.')
 # Meson variables defined there.
 subdir('tools/i2c')
 
+if get_option('ibm-ups')
+    subdir('ibm-ups')
+endif
 if get_option('regulators')
     subdir('phosphor-regulators')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -44,6 +44,10 @@ option(
     description: 'Enable support for cold redundancy'
 )
 option(
+    'ibm-ups', type: 'boolean',
+    description: 'Enable support for IBM UPS monitoring'
+)
+option(
     'supply-monitor', type: 'boolean',
     description: 'Enable support for power supply monitoring'
 )

--- a/services/ibm-ups.service
+++ b/services/ibm-ups.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=IBM UPS monitor
+Wants=obmc-mapper.target
+After=obmc-mapper.target
+
+[Service]
+Restart=on-failure
+ExecStart=/usr/bin/ibm-ups
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Create an initial version of the ibm-ups application.  This application
will eventually monitor an Uninterruptible Power Supply (UPS).

The UPS must be connected to a USB port on the BMC using an IBM "System
Port Converter Cable".  The application will eventually read the UPS
status from the cable and publish it on D-Bus using the UPower
org.freedesktop.UPower.Device interface.

This initial commit contains the following:
* Meson changes to build the new application
* Minimal C++ implementation that publishes a D-Bus object with default
  property values

The long-term BMC strategy for UPS support is to use the full UPower
software package.  However, a short-term solution is required to support
IBM systems.  For this reason, this application is being developed
downstream.

Signed-off-by: Shawn McCarney <shawnmm@us.ibm.com>
Change-Id: I19357c6351ca56ae7a5181656915c6a2534dd7b3