### PR TITLE
ibm-ups: Add support to poll current UPS status

### DIFF
--- a/ibm-ups/monitor.cpp
+++ b/ibm-ups/monitor.cpp
@@ -16,6 +16,8 @@
 
 #include "monitor.hpp"
 
+#include <functional>
+
 namespace phosphor::power::ibm_ups
 {
 
@@ -25,10 +27,14 @@ namespace phosphor::power::ibm_ups
 constexpr auto serviceName = "xyz.openbmc_project.Power.IBMUPS";
 
 Monitor::Monitor(sdbusplus::bus::bus& bus, const sdeventplus::Event& event) :
-    bus{bus}, eventLoop{event}, ups{bus}
+    bus{bus}, eventLoop{event}, ups{bus},
+    timer{event, std::bind(&Monitor::timerExpired, this)}
 {
     // Obtain D-Bus service name
     bus.request_name(serviceName);
+
+    // Start timer that polls UPS device for current status
+    startTimer();
 }
 
 } // namespace phosphor::power::ibm_ups

--- a/ibm-ups/monitor.hpp
+++ b/ibm-ups/monitor.hpp
@@ -47,6 +47,26 @@ class Monitor
      */
     explicit Monitor(sdbusplus::bus::bus& bus, const sdeventplus::Event& event);
 
+    /**
+     * Disables monitoring of the UPS device.
+     *
+     * The device will not be polled to obtain the current status.
+     */
+    void disable()
+    {
+        isEnabled = false;
+    }
+
+    /**
+     * Enables monitoring of the UPS device.
+     *
+     * The device will be polled to obtain the current status.
+     */
+    void enable()
+    {
+        isEnabled = true;
+    }
+
   private:
     /**
      * D-Bus bus object.
@@ -62,6 +82,14 @@ class Monitor
      * UPS device.
      */
     UPS ups;
+
+    /**
+     * Indicates whether monitoring is enabled.
+     *
+     * When monitoring is enabled, the UPS device will be polled to obtain the
+     * current status.
+     */
+    bool isEnabled{true};
 };
 
 } // namespace phosphor::power::ibm_ups

--- a/ibm-ups/ups.cpp
+++ b/ibm-ups/ups.cpp
@@ -16,8 +16,14 @@
 
 #include "ups.hpp"
 
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
 namespace phosphor::power::ibm_ups
 {
+
+namespace fs = std::filesystem;
 
 /**
  * D-Bus object path for the UPS.
@@ -28,19 +34,245 @@ namespace phosphor::power::ibm_ups
  */
 constexpr auto objectPath = "/org/freedesktop/UPower/devices/ups_hiddev0";
 
-UPS::UPS(sdbusplus::bus::bus& bus) : DeviceObject{bus, objectPath, true}
-{
-    // Set D-Bus properties that do not have the correct default value.  Skip
-    // emitting D-Bus signals until the object has been fully created.
-    bool skipSignal{true};
-    type(device::type::Ups, skipSignal);
-    powerSupply(true, skipSignal);
-    state(device::state::FullyCharged, skipSignal);
-    isRechargeable(true, skipSignal);
-    batteryLevel(device::battery_level::Full, skipSignal);
+/**
+ * Directory where the UPS character device file should exist.
+ */
+const fs::path deviceDirectory = "/dev";
 
-    // Now emit signal that object has been created
-    emit_object_added();
+/**
+ * Expected prefix of the UPS character device file name.
+ */
+constexpr auto deviceNamePrefix = "ttyUSB";
+
+/**
+ * Number of consecutive device read errors before we close the device.
+ *
+ * These errors may indicate the UPS has been removed.
+ */
+constexpr unsigned short maxReadErrorCount{3};
+
+/**
+ * Number of consecutive device reads that must return the same modem bit values
+ * before the values are considered valid.
+ *
+ * This provides de-glitching to ignore a transient event where invalid data is
+ * read.
+ */
+constexpr unsigned short requiredMatchingReadCount{3};
+
+UPS::UPS(sdbusplus::bus::bus& bus) : DeviceObject{bus, objectPath}
+{
+    // Set D-Bus properties to initial values indicating the UPS is not present
+    initializeDBusProperties();
+}
+
+UPS::~UPS()
+{
+    try
+    {
+        if (isDeviceOpen())
+        {
+            closeDevice();
+        }
+    }
+    catch (...)
+    {
+        // Destructors must not throw exceptions
+    }
+}
+
+void UPS::refresh()
+{
+    try
+    {
+        // Open the UPS device if necessary
+        if (!isDeviceOpen())
+        {
+            if (!openDevice())
+            {
+                // Unable to open device; may not be present
+                return;
+            }
+        }
+
+        // Read current status from UPS device
+        readDevice();
+    }
+    catch (...)
+    {
+        // Ignore error in case UPS was removed during the actions above
+    }
+}
+
+void UPS::closeDevice()
+{
+    // Close file descriptor
+    close(fd);
+    fd = INVALID_FD;
+
+    // Clear data members used to open and read the device
+    devicePath.clear();
+    readErrorCount = 0;
+    matchingReadCount = 0;
+    prevModemBits = INVALID_MODEM_BITS;
+
+    // Set D-Bus properties to initial values indicating the UPS is not present
+    initializeDBusProperties();
+}
+
+bool UPS::findDevicePath()
+{
+    devicePath.clear();
+    try
+    {
+        // Loop through all entries in the directory where the file should exist
+        std::string entryName{};
+        for (auto const& entry : fs::directory_iterator{deviceDirectory})
+        {
+            // If entry has expected prefix, exists, and is character device
+            entryName = entry.path().filename().native();
+            if (entryName.starts_with(deviceNamePrefix) && entry.exists() &&
+                entry.is_character_file())
+            {
+                // Found UPS device path
+                devicePath = entry.path();
+                break;
+            }
+        }
+    }
+    catch (...)
+    {
+        // Ignore errors; UPS may have been added/removed during loop
+    }
+    return (!devicePath.empty());
+}
+
+void UPS::handleReadDeviceFailure()
+{
+    // Clear consecutive matching read count and previous modem bits
+    matchingReadCount = 0;
+    prevModemBits = INVALID_MODEM_BITS;
+
+    // Increment consecutive error count
+    if (readErrorCount < maxReadErrorCount)
+    {
+        ++readErrorCount;
+    }
+
+    // If we have reached the maximum number of read errors, close UPS device
+    if (readErrorCount >= maxReadErrorCount)
+    {
+        closeDevice();
+    }
+}
+
+void UPS::handleReadDeviceSuccess(int modemBits)
+{
+    // Clear consecutive read error count
+    readErrorCount = 0;
+
+    // Check if modem bits have changed since the previous read
+    if (modemBits != prevModemBits)
+    {
+        // Modem bits have changed; set matching read count to 1
+        matchingReadCount = 1;
+    }
+    else
+    {
+        // Modem bits have not changed.  Increment matching read count.
+        if (matchingReadCount < requiredMatchingReadCount)
+        {
+            ++matchingReadCount;
+        }
+
+        // If we have reached the required number of matching reads
+        if (matchingReadCount >= requiredMatchingReadCount)
+        {
+            // Get UPS status from modem bit values.
+            bool isOn = static_cast<bool>(modemBits & TIOCM_CAR);
+            bool isBatteryLow = static_cast<bool>(modemBits & TIOCM_CTS);
+            bool isUtilityFail = static_cast<bool>(modemBits & TIOCM_DSR);
+
+            // Update D-Bus properties with current UPS status
+            updateDBusProperties(isOn, isBatteryLow, isUtilityFail);
+        }
+    }
+
+    // Save the modem bit values for comparison during the next read
+    prevModemBits = modemBits;
+}
+
+void UPS::initializeDBusProperties()
+{
+    type(device::type::Ups);
+    powerSupply(true);
+    isPresent(false);
+    state(device::state::FullyCharged);
+    isRechargeable(true);
+    batteryLevel(device::battery_level::Full);
+}
+
+bool UPS::openDevice()
+{
+    bool wasOpened{false};
+
+    // Find UPS device path
+    if (findDevicePath())
+    {
+        // Open device path
+        int rc = open(devicePath.c_str(), O_RDONLY);
+        if (rc >= 0)
+        {
+            fd = rc;
+            wasOpened = true;
+        }
+    }
+
+    return wasOpened;
+}
+
+void UPS::readDevice()
+{
+    // Read modem bits from device driver
+    int modemBits{0};
+    int rc = ioctl(fd, TIOCMGET, &modemBits);
+    if (rc < 0)
+    {
+        handleReadDeviceFailure();
+    }
+    else
+    {
+        handleReadDeviceSuccess(modemBits);
+    }
+}
+
+void UPS::updateDBusProperties(bool isOn, bool isBatteryLow, bool isUtilityFail)
+{
+    // Set D-Bus IsPresent property.  isOn means UPS is present/functional.
+    isPresent(isOn);
+
+    // Set D-Bus State property
+    if (isUtilityFail)
+    {
+        // Utility failure is occurring.  UPS is providing power to the system.
+        state(device::state::Discharging);
+    }
+    else if (isBatteryLow)
+    {
+        // UPS is not providing power to the system, but the battery is low.
+        // Assume the battery is charging.
+        state(device::state::Charging);
+    }
+    else
+    {
+        // UPS is not providing power to the system, and battery is not low.
+        // Assume the battery is fully charged.
+        state(device::state::FullyCharged);
+    }
+
+    // Set D-Bus BatteryLevel property
+    batteryLevel(isBatteryLow ? device::battery_level::Low
+                              : device::battery_level::Full);
 }
 
 } // namespace phosphor::power::ibm_ups


### PR DESCRIPTION
ibm-ups: Add support to poll current UPS status

Add support to the ibm-ups application to poll for the current UPS status by reading
from the USB cable.

Add a new command line option, --no-poll, to disable polling.  This is intended for testing
purposes only.  It allows the UPS status to be manually set on the D-Bus interface using
the busctl command.

See the commit messages for the two related commits in this pull request for more details.