### PR TITLE
ibm-ups: Add ObjectManager interface and error logging

### DIFF
--- a/ibm-ups/error_logging.cpp
+++ b/ibm-ups/error_logging.cpp
@@ -1,0 +1,73 @@
+/**
+ * Copyright © 2022 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "error_logging.hpp"
+
+#include "journal.hpp"
+
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <sdbusplus/message.hpp>
+
+#include <exception>
+
+namespace phosphor::power::ibm_ups::error_logging
+{
+
+void logBatteryDischarging(sdbusplus::bus::bus& bus,
+                           const std::string& devicePath)
+{
+    std::string message{
+        "xyz.openbmc_project.Power.UPS.Error.Battery.Discharging"};
+    std::map<std::string, std::string> additionalData{};
+    additionalData.emplace("UPS_DEVICE_PATH", devicePath);
+    logError(bus, message, Entry::Level::Informational, additionalData);
+}
+
+void logBatteryLow(sdbusplus::bus::bus& bus, const std::string& devicePath)
+{
+    std::string message{"xyz.openbmc_project.Power.UPS.Error.Battery.Low"};
+    std::map<std::string, std::string> additionalData{};
+    additionalData.emplace("UPS_DEVICE_PATH", devicePath);
+    logError(bus, message, Entry::Level::Informational, additionalData);
+}
+
+void logError(sdbusplus::bus::bus& bus, const std::string& message,
+              Entry::Level severity,
+              std::map<std::string, std::string>& additionalData)
+{
+    try
+    {
+        additionalData.emplace("_PID", std::to_string(getpid()));
+
+        // Call D-Bus method to create error log
+        const char* service = "xyz.openbmc_project.Logging";
+        const char* objPath = "/xyz/openbmc_project/logging";
+        const char* interface = "xyz.openbmc_project.Logging.Create";
+        const char* method = "Create";
+        auto reqMsg = bus.new_method_call(service, objPath, interface, method);
+        reqMsg.append(message, severity, additionalData);
+        auto respMsg = bus.call(reqMsg);
+    }
+    catch (const std::exception& e)
+    {
+        journal::logError(e.what());
+        journal::logError("Unable to log error " + message);
+    }
+}
+
+} // namespace phosphor::power::ibm_ups::error_logging

--- a/ibm-ups/error_logging.hpp
+++ b/ibm-ups/error_logging.hpp
@@ -1,0 +1,65 @@
+/**
+ * Copyright © 2022 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "xyz/openbmc_project/Logging/Entry/server.hpp"
+
+#include <sdbusplus/bus.hpp>
+
+#include <map>
+#include <string>
+
+/**
+ * This namespace contains utility functions to simplify logging UPS errors.
+ */
+namespace phosphor::power::ibm_ups::error_logging
+{
+using namespace sdbusplus::xyz::openbmc_project::Logging::server;
+
+/**
+ * Log an error indicating that the UPS battery is discharging due to a utility
+ * failure.
+ *
+ * @param bus D-Bus bus object
+ * @param devicePath path to the UPS device
+ */
+void logBatteryDischarging(sdbusplus::bus::bus& bus,
+                           const std::string& devicePath);
+
+/**
+ * Log an error indicating that the UPS battery level is low.
+ *
+ * @param bus D-Bus bus object
+ * @param devicePath path to the UPS device
+ */
+void logBatteryLow(sdbusplus::bus::bus& bus, const std::string& devicePath);
+
+/**
+ * Log an error using the D-Bus Create method.
+ *
+ * If logging fails, a message is written to the journal but an exception is
+ * not thrown.
+ *
+ * @param bus D-Bus bus object
+ * @param message Message property of the error log entry
+ * @param severity Severity property of the error log entry
+ * @param additionalData AdditionalData property of the error log entry
+ */
+void logError(sdbusplus::bus::bus& bus, const std::string& message,
+              Entry::Level severity,
+              std::map<std::string, std::string>& additionalData);
+
+} // namespace phosphor::power::ibm_ups::error_logging

--- a/ibm-ups/journal.hpp
+++ b/ibm-ups/journal.hpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright © 2022 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <phosphor-logging/log.hpp>
+
+#include <string>
+
+/**
+ * This namespace contains utility functions to simplify writing messages to the
+ * system journal.
+ */
+namespace phosphor::power::ibm_ups::journal
+{
+
+/**
+ * Logs an error message in the system journal.
+ *
+ * @param message message to log
+ */
+inline void logError(const std::string& message)
+{
+    using namespace phosphor::logging;
+    log<level::ERR>(message.c_str());
+}
+
+/**
+ * Logs an informational message in the system journal.
+ *
+ * @param message message to log
+ */
+inline void logInfo(const std::string& message)
+{
+    using namespace phosphor::logging;
+    log<level::INFO>(message.c_str());
+}
+
+} // namespace phosphor::power::ibm_ups::journal

--- a/ibm-ups/main.cpp
+++ b/ibm-ups/main.cpp
@@ -42,6 +42,9 @@ int main(int argc, const char* argv[])
         auto event = sdeventplus::Event::get_default();
         bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
 
+        // Obtain D-Bus service name
+        bus.request_name("xyz.openbmc_project.Power.IBMUPS");
+
         // Create UPS monitor
         Monitor monitor{bus, event};
         if (isPollingDisabled)

--- a/ibm-ups/meson.build
+++ b/ibm-ups/meson.build
@@ -1,5 +1,6 @@
 ibm_ups = executable(
     'ibm-ups',
+    'error_logging.cpp',
     'main.cpp',
     'monitor.cpp',
     'ups.cpp',

--- a/ibm-ups/monitor.cpp
+++ b/ibm-ups/monitor.cpp
@@ -22,17 +22,14 @@ namespace phosphor::power::ibm_ups
 {
 
 /**
- * D-Bus service/bus name for this application.
+ * Root D-Bus object path for this application.
  */
-constexpr auto serviceName = "xyz.openbmc_project.Power.IBMUPS";
+constexpr auto rootObjectPath = "/org/freedesktop/UPower";
 
 Monitor::Monitor(sdbusplus::bus::bus& bus, const sdeventplus::Event& event) :
-    bus{bus}, eventLoop{event}, ups{bus},
+    bus{bus}, eventLoop{event}, manager{bus, rootObjectPath}, ups{bus},
     timer{event, std::bind(&Monitor::timerExpired, this)}
 {
-    // Obtain D-Bus service name
-    bus.request_name(serviceName);
-
     // Start timer that polls UPS device for current status
     startTimer();
 }

--- a/ibm-ups/monitor.hpp
+++ b/ibm-ups/monitor.hpp
@@ -18,6 +18,7 @@
 #include "ups.hpp"
 
 #include <sdbusplus/bus.hpp>
+#include <sdbusplus/server/manager.hpp>
 #include <sdeventplus/event.hpp>
 #include <sdeventplus/utility/timer.hpp>
 
@@ -115,6 +116,14 @@ class Monitor
      * Event object to loop on.
      */
     const sdeventplus::Event& eventLoop;
+
+    /**
+     * D-Bus object manager.
+     *
+     * Causes this application to implement the
+     * org.freedesktop.DBus.ObjectManager interface.
+     */
+    sdbusplus::server::manager_t manager;
 
     /**
      * UPS device.

--- a/ibm-ups/ups.hpp
+++ b/ibm-ups/ups.hpp
@@ -131,8 +131,11 @@ class UPS : public DeviceObject
 
     /**
      * Set D-Bus properties to initial values indicating the UPS is not present.
+     *
+     * @param skipSignals indicates whether to skip emitting D-Bus property
+     *                    changed signals
      */
-    void initializeDBusProperties();
+    void initializeDBusProperties(bool skipSignals = false);
 
     /**
      * Returns whether the UPS device has been opened.
@@ -175,6 +178,11 @@ class UPS : public DeviceObject
      * Invalid value for the modem bits read from the UPS device.
      */
     static constexpr int INVALID_MODEM_BITS{-1};
+
+    /**
+     * D-Bus bus object.
+     */
+    sdbusplus::bus::bus& bus;
 
     /**
      * File system path to the UPS device.

--- a/ibm-ups/ups.hpp
+++ b/ibm-ups/ups.hpp
@@ -170,6 +170,17 @@ class UPS : public DeviceObject
     void updateDBusProperties(bool isOn, bool isBatteryLow, bool isUtilityFail);
 
     /**
+     * Update the error status of the UPS device.
+     *
+     * Log errors or clear error history based on the current UPS status.
+     *
+     * @param isBatteryLow specifies whether the UPS battery level is low
+     * @param isUtilityFail specifies whether the UPS is providing power
+     *                      to the system due to a utility failure
+     */
+    void updateErrorStatus(bool isBatteryLow, bool isUtilityFail);
+
+    /**
      * Invalid value for a file descriptor.
      */
     static constexpr int INVALID_FD{-1};
@@ -212,6 +223,18 @@ class UPS : public DeviceObject
      * Modem bits previously read from the UPS device.
      */
     int prevModemBits{INVALID_MODEM_BITS};
+
+    /**
+     * Indicates whether an error has been logged because the UPS battery
+     * is discharging due to a utility failure.
+     */
+    bool hasLoggedBatteryDischarging{false};
+
+    /**
+     * Indicates whether an error has been logged because the UPS battery
+     * level is low.
+     */
+    bool hasLoggedBatteryLow{false};
 };
 
 } // namespace phosphor::power::ibm_ups


### PR DESCRIPTION
This pull request makes the following enhancements to the ibm-ups application:
* Add the org.freedesktop.DBus.ObjectManager interface.
* Log an error when a Utility Failure or Low Battery event occurs.

See the individual commits for more details on the enhancements that were made and the testing that was performed.  Click on the 'Commits' tab, and then click on each commit.