### PR TITLE
ibm-ups: Fix race condition with state manager

### DIFF
--- a/ibm-ups/main.cpp
+++ b/ibm-ups/main.cpp
@@ -42,9 +42,6 @@ int main(int argc, const char* argv[])
         auto event = sdeventplus::Event::get_default();
         bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
 
-        // Obtain D-Bus service name
-        bus.request_name("xyz.openbmc_project.Power.IBMUPS");
-
         // Create UPS monitor
         Monitor monitor{bus, event};
         if (isPollingDisabled)
@@ -52,6 +49,9 @@ int main(int argc, const char* argv[])
             // Disable monitoring/polling of the UPS device
             monitor.disable();
         }
+
+        // Obtain D-Bus service name
+        bus.request_name("xyz.openbmc_project.Power.IBMUPS");
 
         rc = event.loop();
     }

--- a/ibm-ups/ups.hpp
+++ b/ibm-ups/ups.hpp
@@ -109,6 +109,49 @@ class UPS : public DeviceObject
     void closeDevice();
 
     /**
+     * Force a PropertiesChanged event to be emitted for the BatteryLevel
+     * property.
+     */
+    void emitBatteryLevelChangedEvent()
+    {
+        // Save current value, change property without emitting a signal, and
+        // then change back to the saved value.  There is no direct way to force
+        // the signal to be emitted using the sdbusplus API.
+        bool skipSignal{true};
+        uint32_t value = batteryLevel();
+        batteryLevel(device::battery_level::Unknown, skipSignal);
+        batteryLevel(value);
+    }
+
+    /**
+     * Force a PropertiesChanged event to be emitted for the IsPresent property.
+     */
+    void emitIsPresentChangedEvent()
+    {
+        // Save current value, change property without emitting a signal, and
+        // then change back to the saved value.  There is no direct way to force
+        // the signal to be emitted using the sdbusplus API.
+        bool skipSignal{true};
+        bool value = isPresent();
+        isPresent(!value, skipSignal);
+        isPresent(value);
+    }
+
+    /**
+     * Force a PropertiesChanged event to be emitted for the State property.
+     */
+    void emitStateChangedEvent()
+    {
+        // Save current value, change property without emitting a signal, and
+        // then change back to the saved value.  There is no direct way to force
+        // the signal to be emitted using the sdbusplus API.
+        bool skipSignal{true};
+        uint32_t value = state();
+        state(device::state::Unknown, skipSignal);
+        state(value);
+    }
+
+    /**
      * Find the file system path to the UPS device.
      *
      * If found, the path is stored in the devicePath data member.

--- a/services/ibm-ups.service
+++ b/services/ibm-ups.service
@@ -1,11 +1,14 @@
 [Unit]
 Description=IBM UPS monitor
+Before=xyz.openbmc_project.State.Chassis.service
 Wants=obmc-mapper.target
 After=obmc-mapper.target
 
 [Service]
 Restart=on-failure
 ExecStart=/usr/bin/ibm-ups
+Type=dbus
+BusName=xyz.openbmc_project.Power.IBMUPS
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fix a possible race condition with the phosphor-chassis-state-manager
application.

The ibm-ups application requires at least three matching reads from the
UPS device before the status bits are considered valid.  This is
intended to avoid transitory read issues that produce invalid data.

Previously, a UPS Device object was created on D-Bus with initial
property values indicating that the UPS was not present.  After three
matching reads, the properties were updated to contain the actual UPS
status.

This behavior could cause problems for the
phosphor-chassis-state-manager application.  It monitors the UPS D-Bus
properties in order to decide whether to perform an auto-power-restart
of the system.

If phosphor-chassis-state-manager read the D-Bus properties after the
UPS object was created but before three matching reads, it would
incorrectly assume no UPS was present.  As a result, it might perform an
auto-power-restart when it should not due to a low UPS battery.

This commit makes the following changes to fix this race condition:
* Modifies the ibm-ups systemd service file
  * Specifies that ibm-ups is a D-Bus application and that it has not
    finished starting until it claims the service/bus name.
  * Specifies that ibm-ups needs to be started before the
    phosphor-chassis-state-manager application.
* Does four reads from the UPS device when initially creating the D-Bus
  UPS object.  This should ensure it contains the actual UPS status.

Also made a minor change to mask off (ignore) modem status bits that are
not used by the ibm-ups application.  This avoids a potential problem
where changes in irrelevant bits could cause consecutive reads to be
considered non-matching and not valid.

Tested:
* Verified phosphor-chassis-state-manager does not start until after the
  ibm-ups application has claimed the D-Bus service/bus name.
* Verified ibm-ups application does not claim the D-Bus bus name until
  after it has polled the UPS device 4 times to obtain the actual UPS
  status.
* Verified that phosphor-chassis-state-manager receives forced
  PropertiesChanged signals if the ibm-ups application is restarted.
* Verified that PLDM receives forced PropertiesChanged signals if the
  ibm-ups application is restarted.
* Verified that extraneous modem bits are masked off (ignored) when
  reading the UPS status.

Signed-off-by: Shawn McCarney <shawnmm@us.ibm.com>
Change-Id: I3167cceae40826319571bdd2b08be47d12bcbdfe