### PR TITLE
ibm-ups: Block SIGHUP and SIGCONT

### DIFF
--- a/ibm-ups/main.cpp
+++ b/ibm-ups/main.cpp
@@ -19,6 +19,7 @@
 #include <CLI/CLI.hpp>
 #include <sdbusplus/bus.hpp>
 #include <sdeventplus/event.hpp>
+#include <stdplus/signal.hpp>
 
 #include <exception>
 #include <iostream>
@@ -30,6 +31,10 @@ int main(int argc, const char* argv[])
     int rc{0};
     try
     {
+        // Block SIGHUP and SIGCONT signals that may be sent by UPS driver
+        stdplus::signal::block(SIGHUP);
+        stdplus::signal::block(SIGCONT);
+
         // Parse command line parameters (if any)
         CLI::App app{"IBM UPS Monitor"};
         bool isPollingDisabled{false};

--- a/ibm-ups/meson.build
+++ b/ibm-ups/meson.build
@@ -8,7 +8,8 @@ ibm_ups = executable(
         phosphor_dbus_interfaces,
         phosphor_logging,
         sdbusplus,
-        sdeventplus
+        sdeventplus,
+        stdplus
     ],
     install: true
 )


### PR DESCRIPTION
Block the signals SIGHUP and SIGCONT so that they have no effect.  These
signals may be sent from the UPS device driver, such as when the UPS is
unplugged.

The default Linux behavior for SIGHUP is terminating the application.

Signed-off-by: Shawn McCarney <shawnmm@us.ibm.com>
Change-Id: Iade0706c05a1916be6484662a77834a310dac897