### PR TITLE
ibm-ups: Use object_t constructor with enum arg

### DIFF
--- a/ibm-ups/ups.cpp
+++ b/ibm-ups/ups.cpp
@@ -67,7 +67,7 @@ constexpr unsigned short maxReadErrorCount{3};
 constexpr unsigned short requiredMatchingReadCount{3};
 
 UPS::UPS(sdbusplus::bus::bus& bus) :
-    DeviceObject{bus, objectPath, true}, bus{bus}
+    DeviceObject{bus, objectPath, DeviceObject::action::defer_emit}, bus{bus}
 {
     // Set D-Bus properties to initial values indicating the UPS is not present.
     // Skip emitting D-Bus signals until the object has been fully created.


### PR DESCRIPTION
The sdbusplus object_t constructor with a boolean third argument should
no longer be used.  The constructor with an enum third argument should
be used instead.

Signed-off-by: Shawn McCarney <shawnmm@us.ibm.com>
Change-Id: Ic46b8b6ebecd5c2cbde4434a2c3c27aabfa4771b