### PR TITLE
Reset Everest voltage regulators during BMC boot

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -58,6 +58,7 @@ services = [
     ['regulators', 'phosphor-regulators-config.service'],
     ['regulators', 'phosphor-regulators-monitor-enable.service'],
     ['regulators', 'phosphor-regulators-monitor-disable.service'],
+    ['regulators', 'reset_voltage_regulators.service'],
     ['power-control', 'phosphor-power-control.service'],
 ]
 
@@ -133,6 +134,10 @@ if get_option('ibm-ups')
 endif
 if get_option('regulators')
     subdir('phosphor-regulators')
+    install_data('reset_voltage_regulators',
+            install_mode: 'rwxr-xr-x',
+            install_dir: get_option('bindir')
+    )
 endif
 if get_option('sequencer-monitor')
     subdir('power-sequencer')

--- a/reset_voltage_regulators
+++ b/reset_voltage_regulators
@@ -1,0 +1,5 @@
+#!/usr/bin/python3
+
+import sys
+
+sys.exit(0)

--- a/services/reset_voltage_regulators.service
+++ b/services/reset_voltage_regulators.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Reset voltage regulators
+Before=ibm-ups.service
+Before=xyz.openbmc_project.Software.BMC.Updater.service
+After=phosphor-power-control.service
+Wants=phosphor-power-control.service
+After=mux-workarounds.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/reset_voltage_regulators
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Create a service file that runs a script to reset several voltage
regulators on Everest systems.  This is a hardware-workaround required
due to some unexpected power supply behavior.

The service must run early in the BMC boot process.  It must run before
the following services:
* UPS monitoring
  * One of the affected regulators powers the USB port used to connect
    to a UPS device.
* Software update
  * One of the affected regulators powers the USB port that can be used
    to perform a code update.

The service must run after the following services:
* Power control service
  * Reads a GPIO to determine if the chassis is powered on.  Publishes
    this information on D-Bus.  The script being run needs to check if
    the chassis is powered on.
* MUX work-around
  * The MUX work-around is required in order to access the regulators.

The script that will be run is still under development.  In this commit,
a simple "dummy" script is installed and run as a placeholder.  The
dummy script has the correct file name.  This approach will allow the
service file and build process to be tested and completed without
waiting for the final version of the script.

Signed-off-by: Shawn McCarney <shawnmm@us.ibm.com>
Change-Id: I503fba8ff2f0a272b0300d853ad2e6525be69a71