### PR TITLE
ibm-ups: Remove dependencies on obmc-mapper.target

### DIFF
--- a/services/ibm-ups.service
+++ b/services/ibm-ups.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=IBM UPS monitor
-Before=xyz.openbmc_project.State.Chassis.service
+Before=xyz.openbmc_project.State.Chassis@0.service
 
 [Service]
 Restart=on-failure

--- a/services/ibm-ups.service
+++ b/services/ibm-ups.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=IBM UPS monitor
 Before=xyz.openbmc_project.State.Chassis.service
-Wants=obmc-mapper.target
-After=obmc-mapper.target
 
 [Service]
 Restart=on-failure


### PR DESCRIPTION
Remove dependencies on obmc-mapper.target in the ibm-ups service file.

The mapper is D-Bus activated now, and as a result the community is removing explicit service file dependencies on the mapper.


Change-Id: I4ff5e85054d920d8b128bda8c82933104945218a