### PR TITLE
psu-ng: Put input voltage rating on D-Bus

### DIFF
--- a/phosphor-power-supply/power_supply.hpp
+++ b/phosphor-power-supply/power_supply.hpp
@@ -10,6 +10,7 @@
 
 #include <gpiod.hpp>
 #include <sdbusplus/bus/match.hpp>
+#include <xyz/openbmc_project/Sensor/Value/server.hpp>
 
 #include <filesystem>
 #include <stdexcept>
@@ -45,6 +46,9 @@ static constexpr auto CC_KW_SIZE = 4;
 constexpr auto LOG_LIMIT = 3;
 constexpr auto DEGLITCH_LIMIT = 3;
 constexpr auto PGOOD_DEGLITCH_LIMIT = 5;
+
+using SensorInterface = sdbusplus::xyz::openbmc_project::Sensor::server::Value;
+using SensorObject = sdbusplus::server::object_t<SensorInterface>;
 
 /**
  * @class PowerSupply
@@ -516,6 +520,13 @@ class PowerSupply
         syncHistoryRequired = false;
     }
 
+    /**
+     * @brief Puts the input voltage rating on D-Bus.
+     *
+     * The rating is like 0, 110, 220.
+     */
+    void setInputVoltageRating();
+
   private:
     /** @brief systemd bus member */
     sdbusplus::bus_t& bus;
@@ -940,6 +951,15 @@ class PowerSupply
      * objects.
      **/
     std::string historyObjectPath;
+
+    /**
+     * @brief The D-Bus object for the input voltage rating
+     *
+     * It is updated at startup and power on.  If a power supply is
+     * added or removed after that, it does not need to be updated
+     * again (though that could be done as a future improvement).
+     */
+    std::unique_ptr<SensorObject> inputVoltageRatingIface;
 };
 
 } // namespace phosphor::power::psu

--- a/phosphor-power-supply/psu_manager.cpp
+++ b/phosphor-power-supply/psu_manager.cpp
@@ -37,7 +37,8 @@ constexpr auto INPUT_HISTORY_SYNC_DELAY = 5;
 PSUManager::PSUManager(sdbusplus::bus_t& bus, const sdeventplus::Event& e) :
     bus(bus), powerSystemInputs(bus, powerSystemsInputsObjPath),
     objectManager(bus, objectManagerObjPath),
-    historyManager(bus, "/org/open_power/sensors")
+    historyManager(bus, "/org/open_power/sensors"),
+    sensorsObjManager(bus, "/xyz/openbmc_project/sensors")
 {
     // Subscribe to InterfacesAdded before doing a property read, otherwise
     // the interface could be created after the read attempt but before the
@@ -424,6 +425,7 @@ void PSUManager::powerStateChanged(sdbusplus::message_t& msg)
             clearFaults();
             syncHistory();
             setPowerConfigGPIO();
+            setInputVoltageRating();
         }
         else
         {

--- a/phosphor-power-supply/psu_manager.hpp
+++ b/phosphor-power-supply/psu_manager.hpp
@@ -371,6 +371,15 @@ class PSUManager
     sdbusplus::server::manager_t historyManager;
 
     /**
+     * @brief Implement the ObjectManager for the input voltage rating.
+     *
+     * Implements the org.freedesktop.DBus.ObjectManager interface used to
+     * communicate updates to the input voltage ratings on the
+     * /xyz/openbmc_project/sensors root D-Bus path.
+     */
+    sdbusplus::server::manager_t sensorsObjManager;
+
+    /**
      * @brief GPIO to toggle to 'sync' power supply input history.
      */
     std::unique_ptr<GPIOInterfaceBase> syncHistoryGPIO = nullptr;
@@ -388,6 +397,18 @@ class PSUManager
      * start fresh.
      */
     void syncHistory();
+
+    /**
+     * @brief Tells each PSU to set its power supply input
+     *        voltage rating D-Bus property.
+     */
+    inline void setInputVoltageRating()
+    {
+        for (auto& psu : psus)
+        {
+            psu->setInputVoltageRating();
+        }
+    }
 };
 
 } // namespace phosphor::power::manager


### PR DESCRIPTION
IBM systems must tell the BIOS (called hostboot) the power supply input voltage rating during a boot, where the rating is 110 or 220.  This is done via PLDM BIOS attributes where the attribute is backed by a D-Bus property.

This commit adds support for that by putting the input voltage rating of each PS on D-Bus using the Value property of the xyz.openbmc_project.Sensor.Value interface. The path is like /xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating.

$ busctl get-property xyz.openbmc_project.Power.PSUMonitor \
  /xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating \
  xyz.openbmc_project.Sensor.Value Value
d 220

$ busctl get-property xyz.openbmc_project.Power.PSUMonitor \
  /xyz/openbmc_project/sensors/voltage/ps0_input_voltage_rating \
  xyz.openbmc_project.Sensor.Value Unit
s "xyz.openbmc_project.Sensor.Value.Unit.Volts"

These D-Bus objects won't have any associations, unlike normal sensors, so they will not show up in any Redfish output as a sensor.

The interface is only created for present power supplies, and is only updated when the application starts up and when the boot starts.

If a power supply is hot added or removed after that, the D-Bus property doesn't need to be updated as hostboot has already consumed it.

Change-Id: I277516e8d86f1ba1a75b75fe76c67f192d911f88