### PR TITLE
psu-ng: Remove power rating prop if PS not present

### DIFF
--- a/phosphor-power-supply/power_supply.cpp
+++ b/phosphor-power-supply/power_supply.cpp
@@ -1172,6 +1172,11 @@ void PowerSupply::setInputVoltageRating()
 {
     if (!present)
     {
+        if (inputVoltageRatingIface)
+        {
+            inputVoltageRatingIface->value(0);
+            inputVoltageRatingIface.reset();
+        }
         return;
     }
 


### PR DESCRIPTION
When the power is turned on, the input power rating properties were only being created or updated, and if the PS wasn't present nothing was being done.  So if a PS was previously present but was removed, its property would stay on D-Bus.

Fix that by deleting the interface if the PS isn't present at the time of the check.

As PLDM is listening for this and it doesn't handle InterfacesRemoved signals, also set the value to zero before removing it so that they will at least see a value of zero for the missing PS.

At the time of this writing, the only consumer of this property was hostboot (the BIOS for IBM systems) via PLDM, and they were also checking if the PS was present before using it so technically they weren't broken, but it's good to fix it anyway because it's misleading.

Change-Id: I708014bdb12288d95e77028186b38a812f87e916