### PR TITLE
psu-ng: Validate PSUs voltage input

### DIFF
--- a/phosphor-power-supply/psu_manager.cpp
+++ b/phosphor-power-supply/psu_manager.cpp
@@ -894,7 +894,37 @@ void PSUManager::validateConfig()
     if (supported)
     {
         runValidateConfig = false;
-        return;
+        double actualVoltage;
+        int inputVoltage;
+        int previousInputVoltage = 0;
+        bool voltageMismatch = false;
+
+        for (const auto& psu : psus)
+        {
+            if (!psu->isPresent())
+            {
+                // Only present PSUs report a valid input voltage
+                continue;
+            }
+            psu->getInputVoltage(actualVoltage, inputVoltage);
+            if (previousInputVoltage && inputVoltage &&
+                (previousInputVoltage != inputVoltage))
+            {
+                additionalData["EXPECTED_VOLTAGE"] =
+                    std::to_string(previousInputVoltage);
+                additionalData["ACTUAL_VOLTAGE"] =
+                    std::to_string(actualVoltage);
+                voltageMismatch = true;
+            }
+            if (!previousInputVoltage && inputVoltage)
+            {
+                previousInputVoltage = inputVoltage;
+            }
+        }
+        if (!voltageMismatch)
+        {
+            return;
+        }
     }
 
     // Validation failed, create an error log.


### PR DESCRIPTION
Added logic to verify all power supplies have same input voltage. When detecting different input voltage an error is logged.

Tested:
The power input verification test was done on a system with two different input voltage (110v and 220v) in the following scenarios:

- Chassis Off/On.
- Restart the PSU monitor.
- Stop entity manager and stop PSU monitor then start PSU monitor after few seconds start entity manager.
- AC power Off/On.
- Hot-Plug power supply.

All scenarios listed above verified to report one error log.

Change-Id: I85cb06517cbcc82cd478aecca0d5ee01eb1cead1