### PR TITLE
psu-ng: Bypass ACBEL unsupported features

### DIFF
--- a/phosphor-power-supply/psu_manager.cpp
+++ b/phosphor-power-supply/psu_manager.cpp
@@ -547,23 +547,24 @@ void PSUManager::createError(const std::string& faultName,
 
 void PSUManager::syncHistory()
 {
-    log<level::INFO>("Synchronize INPUT_HISTORY");
-
-    if (!syncHistoryGPIO)
+    if (driverName != ACBEL_FSG032_DD_NAME)
     {
-        syncHistoryGPIO = createGPIO(INPUT_HISTORY_SYNC_GPIO);
-    }
-    if (syncHistoryGPIO)
-    {
-        const std::chrono::milliseconds delay{INPUT_HISTORY_SYNC_DELAY};
-        syncHistoryGPIO->toggleLowHigh(delay);
-        for (auto& psu : psus)
+        if (!syncHistoryGPIO)
         {
-            psu->clearSyncHistoryRequired();
+            syncHistoryGPIO = createGPIO(INPUT_HISTORY_SYNC_GPIO);
+        }
+        if (syncHistoryGPIO)
+        {
+            const std::chrono::milliseconds delay{INPUT_HISTORY_SYNC_DELAY};
+            log<level::INFO>("Synchronize INPUT_HISTORY");
+            syncHistoryGPIO->toggleLowHigh(delay);
+            for (auto& psu : psus)
+            {
+                psu->clearSyncHistoryRequired();
+            }
+            log<level::INFO>("Synchronize INPUT_HISTORY completed");
         }
     }
-
-    log<level::INFO>("Synchronize INPUT_HISTORY completed");
 }
 
 void PSUManager::analyze()


### PR DESCRIPTION
ACBEL does not support  input history and sync history, therefore a condition statement was added to prevent execution of input history, sync history.

Test:
   * Verified no error logged when powered on/off
   * Verified no sync history when ACBEL PSU present
   * Verified no change to sync history on IBM PSU
   * Verified PSU metrics listed  in redfish for ACBEL PSU and IBM PSU.

Change-Id: I62db9ef63cddd144afe9eafc8c3de06dd808a30a