### PR TITLE
psu-ng: Fix race condition within PSU monitor.

### DIFF
--- a/phosphor-power-supply/psu_manager.hpp
+++ b/phosphor-power-supply/psu_manager.hpp
@@ -30,9 +30,11 @@ using PowerSystemInputsInterface = sdbusplus::xyz::openbmc_project::State::
 using PowerSystemInputsObject =
     sdbusplus::server::object_t<PowerSystemInputsInterface>;
 
-// Validation timeout. Allow 10s to detect if new EM interfaces show up in D-Bus
+// Validation timeout. Allow 30s to detect if new EM interfaces show up in D-Bus
 // before performing the validation.
-constexpr auto validationTimeout = std::chrono::seconds(10);
+// Previously the timer was set to 10 seconds was too short, it results in
+// incorrect errors being logged, but no real consequence of longer timeout.
+constexpr auto validationTimeout = std::chrono::seconds(30);
 
 /**
  * @class PowerSystemInputs


### PR DESCRIPTION
Modified validationTimeout to 30 seconds to give entity manager enough time to post PSU information.  Previous timer was set to 10 seconds, it was going off before the PSU information available which caused  PSUManager::analyze() method to log incorrect error

     "The power supply configuration is not supported"

During analysis found out on some IBM systems took the entity manager 15 seconds after boot to post the PSU information.

Test:

  * Tested on the system where the defect was consistent to reproduce
  * Tested IBM systems with supported PSUs.

Change-Id: Ib96c5bd4dbe9b989e0e22763a70d746ff1578a23