### PR TITLE
Remove ibm-ups from meson.options

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -49,10 +49,6 @@ option(
     description: 'Enable support for cold redundancy'
 )
 option(
-    'ibm-ups', type: 'boolean',
-    description: 'Enable support for IBM UPS monitoring'
-)
-option(
     'supply-monitor', type: 'boolean',
     description: 'Enable support for power supply monitoring'
 )


### PR DESCRIPTION
The ibm-ups application has been moved from the phosphor-power repository to a separate repository.

During the middle of the move, the ibm-ups meson option needed to remain valid to avoid inter-repository dependencies.  The bitbake recipe in the openbmc repository needed to use this option.

The bitbake recipe has been updated to remove use of this option, so it can now be removed from meson.options.

Tested:
* Built phosphor-power
* Build obmc-phosphor-image

Change-Id: I49d6d499b9e6a383af46a11469f7022d15ed8ae0