### PR TITLE
psu-ng: Fixed PSU monitor app not to report error on valid configuration

### DIFF
--- a/phosphor-power-supply/psu_manager.cpp
+++ b/phosphor-power-supply/psu_manager.cpp
@@ -593,7 +593,8 @@ void PSUManager::analyze()
         {
             std::map<std::string, std::string> additionalData;
 
-            if (!psu->isFaultLogged() && !psu->isPresent())
+            if (!psu->isFaultLogged() && !psu->isPresent() &&
+                !validationTimer->isEnabled())
             {
                 std::map<std::string, std::string> requiredPSUsData;
                 auto requiredPSUsPresent = hasRequiredPSUs(requiredPSUsData);


### PR DESCRIPTION
Modified the PSU monitor app not to report error when the PSU is not present and the PSU validation timer active; or PSU present but we don't have infomation from Entity Manager (EM),the application will have to wait for EM info while the validation timer active before reporting error.

Note: The fix was done due to sometime Entity manager gets busy may delay to post PSU information which causes this application to post invalid PSU error.

Tested:
  1 - On system with 4 PSUs and chassis powered on, with modified code
      to allow  3 PSU interfaces and ignore the 4th interface.
    * Verified error reported after the validation timer expired.
  2 - On system requires 4 PSUs I removed 1 PSU, powered on the chassis
      rebooted BMC with the fix
    * Verified the system reported error after the validation timer
      expired
  3 - Ran a good machine pass with the fix and verified no error
      reported.

Change-Id: I122a3a59ac3def19ae553aea5a6dbd809d324a40