### PR TITLE
pmbus: Safely call std::filesystem::canonical()

### DIFF
--- a/.flake8-ignore
+++ b/.flake8-ignore
@@ -1,0 +1,1 @@
+reset_voltage_regulators

--- a/meson.build
+++ b/meson.build
@@ -196,9 +196,10 @@ subdir('tools/i2c')
 
 if get_option('regulators')
     subdir('phosphor-regulators')
-    install_data('reset_voltage_regulators',
-            install_mode: 'rwxr-xr-x',
-            install_dir: get_option('bindir')
+    install_data(
+        'reset_voltage_regulators',
+        install_mode: 'rwxr-xr-x',
+        install_dir: get_option('bindir'),
     )
 endif
 if get_option('sequencer-monitor')

--- a/pmbus.cpp
+++ b/pmbus.cpp
@@ -17,6 +17,7 @@
 
 #include <phosphor-logging/elog-errors.hpp>
 #include <phosphor-logging/elog.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/Common/Device/error.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
@@ -43,6 +44,28 @@ struct FileCloser
         fclose(fp);
     }
 };
+
+/**
+ * @brief Returns the canonical path if it exists
+ *        otherwise returns the path passed in.
+ *
+ * @param[in] path - The path to check
+ *
+ * @return fs::path - Either the canonical or original path
+ */
+static fs::path tryCanonical(const fs::path& path)
+{
+    std::error_code ec;
+    auto canonical = fs::canonical(path, ec);
+
+    if (ec)
+    {
+        lg2::error("Could not get canonical path from {PATH}", "PATH", path);
+        return path;
+    }
+
+    return canonical;
+}
 
 std::string PMBus::insertPageNum(const std::string& templateName, size_t page)
 {
@@ -161,7 +184,7 @@ bool PMBus::readBit(const std::string& name, Type type)
 
         elog<ReadFailure>(
             metadata::CALLOUT_ERRNO(rc),
-            metadata::CALLOUT_DEVICE_PATH(fs::canonical(basePath).c_str()));
+            metadata::CALLOUT_DEVICE_PATH(tryCanonical(basePath).c_str()));
     }
 
     return value != 0;
@@ -204,7 +227,7 @@ uint64_t PMBus::read(const std::string& name, Type type, bool errTrace)
 
             elog<ReadFailure>(
                 metadata::CALLOUT_ERRNO(rc),
-                metadata::CALLOUT_DEVICE_PATH(fs::canonical(basePath).c_str()));
+                metadata::CALLOUT_DEVICE_PATH(tryCanonical(basePath).c_str()));
         }
         else
         {
@@ -242,7 +265,7 @@ std::string PMBus::readString(const std::string& name, Type type)
 
         elog<ReadFailure>(
             metadata::CALLOUT_ERRNO(rc),
-            metadata::CALLOUT_DEVICE_PATH(fs::canonical(basePath).c_str()));
+            metadata::CALLOUT_DEVICE_PATH(tryCanonical(basePath).c_str()));
     }
 
     return data;
@@ -284,7 +307,7 @@ std::vector<uint8_t> PMBus::readBinary(const std::string& name, Type type,
 
                 elog<ReadFailure>(metadata::CALLOUT_ERRNO(rc),
                                   metadata::CALLOUT_DEVICE_PATH(
-                                      fs::canonical(basePath).c_str()));
+                                      tryCanonical(basePath).c_str()));
             }
         }
         return data;
@@ -320,7 +343,7 @@ void PMBus::write(const std::string& name, int value, Type type)
 
         elog<WriteFailure>(
             metadata::CALLOUT_ERRNO(rc),
-            metadata::CALLOUT_DEVICE_PATH(fs::canonical(basePath).c_str()));
+            metadata::CALLOUT_DEVICE_PATH(tryCanonical(basePath).c_str()));
     }
 }
 
@@ -358,7 +381,7 @@ void PMBus::writeBinary(const std::string& name, std::vector<uint8_t> data,
 
         elog<WriteFailure>(
             metadata::CALLOUT_ERRNO(rc),
-            metadata::CALLOUT_DEVICE_PATH(fs::canonical(basePath).c_str()));
+            metadata::CALLOUT_DEVICE_PATH(tryCanonical(basePath).c_str()));
     }
 }
 

--- a/reset_voltage_regulators
+++ b/reset_voltage_regulators
@@ -2,8 +2,9 @@
 #
 # Script to reset faults in all VRMs.
 #
-import sys
+# fmt: off
 import subprocess
+import sys
 from collections import namedtuple
 
 DEBUG = 0


### PR DESCRIPTION
There are a few different places where CALLOUT_DEVICE_PATH elog metadata is used that passes in the result of a std::filesystem::canonical() call.

That function will throw if the path passed in does not exist. Since that code isn't in a try/catch block, the application will crash.

Fix that by using the version of the function that sets a std::error_code in an output parameter to indicate failure.  If it does fail, then just use the original path given to it.

As canonical() was used for a reason, there may be side affects such as proper error analysis not being done, but there is not much that can be done about that.

Tested:
The app doesn't crash, and can see:

```
Failed to read sysfs file errno=2 FILENAME=/sys/kernel/debug/pmbus/status0
Could not get canonical path from /sys/bus/i2c/devices/3-006a
Failed to read from the device.
```

And in the event log
```
"CALLOUT_DEVICE_PATH" "/sys/bus/i2c/devices/3-006a"
```

Change-Id: I9ea374dc685cc325b40a1f2bb0c8ae0ce71df650