### PR TITLE
1120: psu-ng: Modified logic to handle 12V MFR warning (#29)

### DIFF
--- a/phosphor-power-supply/power_supply.cpp
+++ b/phosphor-power-supply/power_supply.cpp
@@ -497,6 +497,25 @@ void PowerSupply::analyzeMFRFault()
     {
         if (mfrFault < DEGLITCH_LIMIT)
         {
+            if ((statusMFR & 0x80) && driverName == IBMCFFPS_DD_NAME)
+            {
+                // Report current share warning once per boot
+                if (!currentShareWarningReported)
+                {
+                    log<level::INFO>(
+                        std::format("{} 12V current share warning: "
+                                    "STATUS_WORD = {:#06x} "
+                                    "STATUS_MFR_SPECIFIC = {:#04x}",
+                                    shortName, statusWord, statusMFR)
+                            .c_str());
+                    currentShareWarningReported = true;
+                }
+                statusMFR = statusMFR & 0x7F;
+            }
+            if (!statusMFR)
+            {
+                return;
+            }
             if (statusWord != statusWordOld)
             {
                 log<level::ERR>(std::format("{} MFR fault: "

--- a/phosphor-power-supply/power_supply.hpp
+++ b/phosphor-power-supply/power_supply.hpp
@@ -157,6 +157,7 @@ class PowerSupply
         ps12VcsFault = 0;
         psCS12VFault = 0;
         faultLogged = false;
+        currentShareWarningReported = false;
     }
 
     /**
@@ -1073,6 +1074,11 @@ class PowerSupply
      * @brief The device driver name
      */
     std::string driverName;
+
+    /**
+     * @brief 12V current share warning reported flag.
+     */
+    bool currentShareWarningReported = false;
 };
 
 } // namespace phosphor::power::psu


### PR DESCRIPTION
#### psu-ng: Modified logic to handle 12V MFR warning (#29)
```
Modified the logic to handle bit 7 (0x80) in MFR warning. The change
include:

    If MFR specific bit 7 (0x80) is set, log informational message
    instead of an error. This informational message logged only once
    during power-on.

    Reset 12V current share warning (bit 7) and leave the existing logic
    in place to check for other bits.

Test:

    On the simulator, set MFR specific word to 0x80 and set the status
    word to 0x1000. Verified the system logged informational message
    with no PELs generated.

    On the simulator, set MFR Specific to 0xC0 and status word to
    0x1000. Verified information error "12V current share warning" was
    logged, and a PEL was reported with SRC "110015F1"

Change-Id: Ie87467aad4596f88316fd1b38b1884448448968e

Signed-off-by: Faisal Awada <faisal@us.ibm.com>```